### PR TITLE
increased max header size for large auth tokens

### DIFF
--- a/vlab_link_api/app.ini
+++ b/vlab_link_api/app.ini
@@ -10,3 +10,4 @@ master = true
 uid = nobody
 gid = nobody
 disable-logging = true
+buffer-size=32768


### PR DESCRIPTION
Increased max HTTP header size in uWSGI to accommodate large auth tokens.